### PR TITLE
Add option for full tunnel mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,9 +127,20 @@ LAN. On Computer 1 or the Laptop, simply add 172.24.0.12 as a printer and print.
 
 You can use zerotier like a traditional VPN. By turning on "allow Default Route"
 in a mobile client's zerotier app, you can encrypt and redirect all its internet
-traffic through your home router. See [this page for further
-information](https://zerotier.atlassian.net/wiki/spaces/SD/pages/7110693/Overriding+Default+Route+Full+Tunnel+Mode). We have not tried this with our Asus setup as yet, but will add more information
-when we get a chance.
+traffic through your home router. Follow these steps:
+
+1. Change the value of the FULL_TUNNEL variable to `"yes"` in `/jffs/scripts/lan-route-table.sh`
+and reboot the router.
+2. In your Zerotier console, add a managed route for `0.0.0.0/0` via your router's Zerotier IP.
+3. In your client, enable full tunnel mode. If your client has a Zerotier GUI
+   (Mac, Windows, iOS, Android), you should be able to find a configuration
+   option labeled *allow Default Route*, *Route all traffic through Zerotier*,
+   or something like that. If you don't have a GUI (Linux), execute  `sudo
+   zerotier-cli set <networkId> allowDefault=1`. For Linux you may also need to
+   set `rp_filter`.
+
+See [this page for further
+information](https://zerotier.atlassian.net/wiki/spaces/SD/pages/7110693/Overriding+Default+Route+Full+Tunnel+Mode). [Also see this...](https://www.digitalocean.com/community/tutorials/getting-started-software-defined-networking-creating-vpn-zerotier-one)
 
 ## Hints and Tips:
 #### Don’t use Zerotier Managed Routes

--- a/scripts/lan-route-table.sh
+++ b/scripts/lan-route-table.sh
@@ -9,6 +9,12 @@ source /jffs/scripts/mylib.sh
 #addRoute "192.168.108.0/24" "10.147.17.64"
 
 # -----------------------------------------
+# Set this to "yes" to enable this router to be
+# the gateway for full tunnel mode.
+FULL_TUNNEL="no"
+
+
+# -----------------------------------------
 # route for this LAN
 #echo "zt iptables:"
 baseZTRoute "10.147.17.0/24"

--- a/scripts/mylib.sh
+++ b/scripts/mylib.sh
@@ -136,6 +136,9 @@ function baseZTRoute() {
 		iptables -I INPUT 1 -i zt+ -j ACCEPT
 		iptables -t nat -I PREROUTING -i zt+ -d $ZT_NETWORK -p tcp -m multiport --dport 21,22,80 -j DNAT --to-destination `nvram get lan_ipaddr`
 		iptables -t nat -A POSTROUTING -o br0 -s $ZT_NETWORK -j SNAT --to-source `nvram get lan_ipaddr`
+                if [ ${FULL_TUNNEL} = "yes" ]; then
+                    iptables -I FORWARD -i zt+ -s $ZT_NETWORK -d 0.0.0.0/0 -j ACCEPT
+                fi
 		iptables -I FORWARD -i zt+ -d `nvram get lan_ipaddr`/24 -j ACCEPT
 		iptables -I FORWARD -i br0 -d $ZT_NETWORK -j ACCEPT
 		sysLOG "zt+ rules added $ZT_NETWORK" notice


### PR DESCRIPTION
This adds an option (off by default) to add an iptable entry to forward zerotier packets to eth0.
It could probably use more testing, but it works for me.

The referenced documents (links in the readme) suggest additional iptable entries, but those documents are targeted towards linux servers that are not already routers. Since the Asus is already a router, it seems this one entry is all that's needed.